### PR TITLE
Fix: Correct validation message for estimated return date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,58 @@
+# Registro de Alterações
+
+Todas as mudanças notáveis neste projeto serão documentadas neste arquivo.
+
+O formato é baseado em [Keep a Changelog](https://keepachangelog.com/pt-BR/1.0.0/), e este projeto adere ao [Versionamento Semântico](https://semver.org/lang/pt-BR/).
+
+---
+
+## [1.1.2] - 2025-09-18
+
+### Corrigido (Fixed)
+- Corrige a mensagem de validação exibida no campo de data de partida.
+
+---
+
+## [1.1.1] - 2025-09-17
+
+### Alterado (Changed)
+- Pasta "public/build" ignorada no versionamento
+
+### Corrigido (Fixed)
+- Corrige a funcionalidade de não salvar o registro da quilometragem do veículo ao banco de dados.
+
+---
+
+## [1.1.0] - 2025-09-16
+
+### Adicionado (Added)
+- Novos avisos de validação e funções de proteção em formulários.
+- Novo botão "Voltar à Página Inicial" na tela de registro de retorno.
+
+---
+
+## [1.0.0] - 2025-09-11
+
+### Adicionado (Added)
+- Lançamento inicial do projeto em produção.
+
+
+## [Não lançado]
+
+### Adicionado (Added)
+- 
+
+### Alterado (Changed)
+- 
+
+### Obsoleto (Deprecated)
+- 
+
+### Removido (Removed)
+- 
+
+### Corrigido (Fixed)
+- 
+
+### Segurança (Security)
+-

--- a/app/Http/Controllers/MovementsVehicleController.php
+++ b/app/Http/Controllers/MovementsVehicleController.php
@@ -36,7 +36,6 @@ class MovementsVehicleController extends Controller
 
     }
 
-
     public function allMovements()
     {
         $movements = VehicleMovement::with(['vehicle', 'driver', 'reason'])
@@ -46,17 +45,6 @@ class MovementsVehicleController extends Controller
         
         return view('movements.allmovements', compact('movements'));
     }
-
-    /**$request->validate([
-            'vehicle_id' => 'required|exists:vehicles,id',
-            'driver_id' => 'required|exists:drivers,id',
-            'reason_id' => 'required|exists:reasons,id',
-            'data_saida' => 'required|date',
-            'estimativa_retorno' => 'required|date',
-            'data_retorno' => 'nullable|date|after:data_saida',
-            'odometro' => 'required|integer|min:0|after:estimativa_retorno',
-            'observacoes' => 'nullable|string|max:255',
-        ]); */
 
     /**
      * Show the form for creating a new resource.
@@ -86,10 +74,16 @@ class MovementsVehicleController extends Controller
             'reason_id' => 'required|exists:reasons,id',
             'data_saida' => 'required|date',
             'estimativa_retorno' => [
-                'required', 'date', 'after:data_saida',
+                'required', 'date',
                 function ($attribute, $value, $fail) use ($request) {
+
+                    if(empty($value) || empty($request->input('data_saida'))){
+                        return; // Se algum dos campos estiver vazio, não faz a validação adicional aqui.
+                    }
+
                     $estimativa = Carbon::parse($value);
                     $saida = Carbon::parse($request->input('data_saida'));
+
                     if (abs($estimativa->diffInMinutes($saida, false)) < 10) {
                         $fail('A estimativa de retorno deve ser de no mínimo 10 minutos.');
                     }
@@ -109,7 +103,7 @@ class MovementsVehicleController extends Controller
                 })
                 ->exists();
 
-            // 2. Lógica corrigida: Se NÃO estiver disponível, falha.
+            // Se NÃO estiver disponível, falha.
             if ($isNotAvailable) {
                 return false; // Falha, pois o veículo ou motorista já está em uso
             }
@@ -125,7 +119,6 @@ class MovementsVehicleController extends Controller
             return redirect()->route('movements.index');
         }
         
-        // 3. Código inalcançável removido daqui.
     }
 
 

--- a/app/Http/Controllers/MovementsVehicleController.php
+++ b/app/Http/Controllers/MovementsVehicleController.php
@@ -62,7 +62,6 @@ class MovementsVehicleController extends Controller
 
         return view('movements.create', compact('vehicles', 'drivers', 'reasons'));
     }
-
     /**
      * Store a newly created resource in storage.
      */
@@ -83,6 +82,10 @@ class MovementsVehicleController extends Controller
 
                     $estimativa = Carbon::parse($value);
                     $saida = Carbon::parse($request->input('data_saida'));
+
+                    if ($estimativa->isBefore($saida)) {
+                        $fail('A estimativa de retorno deve ser posterior à data de saída.');
+                    }
 
                     if (abs($estimativa->diffInMinutes($saida, false)) < 10) {
                         $fail('A estimativa de retorno deve ser de no mínimo 10 minutos.');


### PR DESCRIPTION
## Descrição
Este PR corrige a mensagem de validação que era exibida incorretamente no formulário de agendamento quando o usuário inseria uma estimativa de retorno anterior ao dia/hora atual. A mensagem antiga era genérica e foi substituída.

## Tipo da Mudança
- [x] Correção de bug (Bug fix)
- [ ] Nova funcionalidade (New feature)
- [ ] Quebra de compatibilidade (Breaking change)
- [ ] Mudança de documentação (Documentation update)

## Como Testar
1.  Vá para a página de registrar saída de veículos.
2.  No campo "Estimativa de Retorno", selecione uma data passada (ex: ontem) ou a atual.
3.  Clique fora do campo ou tente enviar o formulário.
4.  **Verifique se a mensagem de erro é exibida corretamente.**

## Issue Relacionada
- Resolve a issue #2 