### PR TITLE
✨ feat: Add number formatting for readability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ O formato é baseado em [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ---
 
+## [1.4.0] - 2025-09-25
+
+### Adicionado
+
+- **Melhoria na formatação e legibilidade de números:**
+    - Adicionada formatação com pontuação (separador de milhar) em todos os valores numéricos exibidos no sistema, facilitando a leitura de grandes números.
+    - Implementada a formatação automática da quilometragem com pontuação enquanto o usuário digita, melhorando a experiência de inserção de dados.
+
+---
+
 ## [1.3.1] - 2025-09-23
 
 ### Corrigido

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,6 +1,10 @@
 @import "tailwindcss";
 @reference "tailwindcss";
 
+body {
+    @apply font-sans;
+}
+
 .table-default {
     @apply border-collapse  border border-gray-400 w-[72.5%] mx-auto h-2/3;
 }

--- a/resources/views/movements/allmovements.blade.php
+++ b/resources/views/movements/allmovements.blade.php
@@ -66,7 +66,7 @@
                         </td>
                         <td class="td-default">{{ \Carbon\Carbon::parse($movement->estimativa_retorno)->format('d/m/Y H:i') }}</td>
                         <td class="td-default">{{ \Carbon\Carbon::parse($movement->data_retorno)->format('d/m/Y H:i') }}</td>
-                        <td class="td-default">{{ $movement->odometro }}</td>
+                        <td class="td-default">{{  number_format($movement->odometro, 0, ',', '.') }}</td>
                         <td class="td-default">{{ $movement->observacao }}</td>
                     </tr>
                 @endforeach
@@ -83,7 +83,7 @@
         @endforeach
     </div>
 </body>
-<footer class="w-full bg-gray-100 py-3 text-center text-xs text-gray-600 border-t">
+<footer class="w-full bg-gray-100 py-3 text-center text-xs text-gray-600">
     Versão {{ config('app.version') }} 
 </footer>
 </html>

--- a/resources/views/movements/return.blade.php
+++ b/resources/views/movements/return.blade.php
@@ -73,7 +73,7 @@
                             Último Valor de Odômetro:
                         </span>
                         <span class="p2-return">
-                            {{ $movement->vehicle->odometro }}
+                            {{ number_format($movement->vehicle->odometro, 0, ',', '.') }} Km
                         </span>
                     </div>
                 </div>
@@ -87,39 +87,44 @@
 
                 <div class="flex flex-col gap-1">
                     <label class="p-return">Odômetro:</label>
-                    <input type="number" name="odometro"
+                    <input type="text" name="odometro" inputmode="numeric"
                         class="input-return @error('odometro') !border-red-600 @enderror"
-                        placeholder="Quilometragem Atual" value="{{ old('odometro', $movement->odometro) }}" required>
+                        placeholder="Quilometragem Atual"
+                        value="{{ old('odometro', $movement->odometro > 0 ? number_format($movement->odometro, 0, ',', '.'): '') }}"
+                        required
+                        oninput="this.value = this.value
+                        .replace(/[^0-9]/g, '')             
+                        .replace(/\B(?=(\d{3})+(?!\d))/g, '.'); // adiciona pontos como separador">
 
                     @error('odometro')
                         <span id="error-odometro" class="danger-message">{{ $message }}</span>
                     @enderror
 
-                    @if(session('warning'))
-                    <div class="warning-message" role="alert">
-                        {{ session('warning') }}
-                    </div>
-                    <input type="hidden" name="confirm_odometro" value="true">
+                    @if (session('warning'))
+                        <div class="warning-message" role="alert">
+                            {{ session('warning') }}
+                        </div>
+                        <input type="hidden" name="confirm_odometro" value="true">
                     @endif
-            </div>
+                </div>
 
-            <div class="flex flex-col gap-1">
-                <label class="p-return">Observações:</label>
-                <textarea name="observacao" rows="2" class="input-return resize-y" placeholder="Digite observações adicionais...">{{old('observacao')}}</textarea>
-            </div>
+                <div class="flex flex-col gap-1">
+                    <label class="p-return">Observações:</label>
+                    <textarea name="observacao" rows="2" class="input-return resize-y" placeholder="Digite observações adicionais...">{{ old('observacao') }}</textarea>
+                </div>
 
-            {{-- Botão --}}
-            <div class="pt-2">
-                <button type="submit"
-                    class="bg-blue-600 hover:bg-blue-700 text-white font-medium px-4 py-2 rounded-lg shadow w-full cursor-pointer">
-                    Finalizar Retorno
-                </button>
-            </div>
-        </form>
-    </div>
-    <footer class="w-full py-3 text-center text-xs text-gray-600 mt-auto">
-        Versão {{ config('app.version') }}
-    </footer>
+                {{-- Botão --}}
+                <div class="pt-2">
+                    <button type="submit"
+                        class="bg-blue-600 hover:bg-blue-700 text-white font-medium px-4 py-2 rounded-lg shadow w-full cursor-pointer">
+                        Finalizar Retorno
+                    </button>
+                </div>
+            </form>
+        </div>
+        <footer class="w-full py-3 text-center text-xs text-gray-600 mt-auto">
+            Versão {{ config('app.version') }}
+        </footer>
 </body>
 
 </html>


### PR DESCRIPTION
## 📝 Descrição

Este PR introduz uma melhoria significativa na **experiência do usuário (UX)** e na **clareza da interface**, implementando a formatação de números com separador de milhar em todo o sistema para resolver a dificuldade de leitura de valores grandes.

- 🎨 **Formatação na Exibição:** Todos os valores numéricos em telas, como na `Página de todas movimentações`, agora são exibidos com separadores de milhar, facilitando a leitura rápida e reduzindo a carga cognitiva.
- ⌨️ **Máscara de Entrada Dinâmica:** O campo de quilometragem em formulários como `Registrar Retorno` aplica a formatação automaticamente enquanto o usuário digita, diminuindo a chance de erros de inserção.
- 🇧🇷 **Padrão Brasileiro:** A formatação utiliza o ponto como separador de milhar (ex: `123.450`), garantindo uma interface mais profissional e localizada.

---

## 🚀 Tipo da Mudança
- [ ] 🐞 Correção de bug (Bug fix)
- [x] ✨ Nova funcionalidade (New feature) - Melhora a legibilidade e usabilidade da interface.
- [ ] 💥 Quebra de compatibilidade (Breaking change)
- [ ] 📚 Mudança de documentação (Documentation update)

---

## ✅ Como Testar

**Cenário 1: Teste de Formatação na Exibição**
1.  ➡️ Acesse a `Página de todas movimentações` ou qualquer tela que exiba a quilometragem.
2.  👀 **Verifique** que um valor que antes era exibido como `123450` agora é apresentado de forma clara como `123.450`.

**Cenário 2: Teste de Formatação na Entrada de Dados (Input)**
1.  ➡️ Navegue até um formulário de entrada de dados, como `Registrar Retorno`.
2.  🔢 No campo de quilometragem, comece a digitar um valor alto (ex: `1234`).
3.  👀 **Observe** que a máscara de formatação é aplicada dinamicamente, exibindo o valor no campo como `1.234`.
4.  ✅ Salve o formulário e **confirme** que o valor foi armazenado corretamente no sistema como um número puro (ex: `1234`), sem a pontuação.

---

## Issue Relacionada
- Resolve a issue (#14 )